### PR TITLE
Add mounted sd v1.5 model

### DIFF
--- a/StableDiffusionUI_Voldemort_paperspace.ipynb
+++ b/StableDiffusionUI_Voldemort_paperspace.ipynb
@@ -363,7 +363,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**v1.5**"
+    "**v1.5**\n",
+    "\n",
+    "Paperspace includes this model in its public data sources, which don't use up your storage quota. To add it, click on `Data Sources` in the toolbar, `Public`, and `stable-diffusion-classic`. The file is mounted at `/datasets/stable-diffusion-classic/`. You only need to do this once, it will stay mounted between sessions. Then run this to link it to your models directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%store -r model_storage_dir\n",
+    "!ln -s \"{model_storage_dir}/v1-5-pruned-emaonly.ckpt\" \"/datasets/stable-diffusion-classic/v1-5-pruned-emaonly.ckpt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If that doesn't work, you can download it manually:"
    ]
   },
   {
@@ -1061,4 +1080,3 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
-


### PR DESCRIPTION
Paperspace recently added the base SD v1.5 model to its public data sources list so you can mount it without using up your storage quota. 