### PR TITLE
use -d option when downloading models with aria2c in case pwd was cha…

### DIFF
--- a/StableDiffusionUI_Voldemort_paperspace.ipynb
+++ b/StableDiffusionUI_Voldemort_paperspace.ipynb
@@ -421,7 +421,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2/resolve/main/768-v-ema.ckpt -o \"{model_storage_dir}/sd-v2-0-768-v-ema.ckpt\"\n",
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2/resolve/main/768-v-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-768-v-ema.ckpt\"\n",
     "!wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-inference-v.yaml -O \"{model_storage_dir}/sd-v2-0-768-v-ema.yaml\""
    ]
   },
@@ -451,7 +451,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-base/resolve/main/512-base-ema.ckpt -o \"{model_storage_dir}/sd-v2-0-512-base-ema.ckpt\"\n",
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-base/resolve/main/512-base-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-512-base-ema.ckpt\"\n",
     "!wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-inference-v.yaml -O \"{model_storage_dir}/sd-v2-0-512-base-ema.yaml\""
    ]
   },
@@ -479,7 +479,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-depth/resolve/main/512-depth-ema.ckpt -o \"{model_storage_dir}/sd-v2-0-512-depth-ema.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-depth/resolve/main/512-depth-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-512-depth-ema.ckpt\""
    ]
   },
   {
@@ -506,7 +506,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-x4-upscaler/resolve/main/x4-upscaler-ema.ckpt -o \"{model_storage_dir}/sd-v2-0-x4-upscaler-ema.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-x4-upscaler/resolve/main/x4-upscaler-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-x4-upscaler-ema.ckpt\""
    ]
   },
   {
@@ -723,7 +723,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step60000.ckpt -o \"{model_storage_dir}/trinart2_step60000.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step60000.ckpt -d \"{model_storage_dir}\" -o \"trinart2_step60000.ckpt\""
    ]
   },
   {
@@ -750,7 +750,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step95000.ckpt -o \"{model_storage_dir}/trinart2_step95000.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step95000.ckpt -d \"{model_storage_dir}\" -o \"trinart2_step95000.ckpt\""
    ]
   },
   {
@@ -777,7 +777,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step115000.ckpt -o \"{model_storage_dir}/trinart2_step115000.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_stable_diffusion_v2/resolve/main/trinart2_step115000.ckpt -d \"{model_storage_dir}\" -o \"trinart2_step115000.ckpt\""
    ]
   },
   {
@@ -806,7 +806,7 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_characters_19.2m_stable_diffusion_v1/resolve/main/trinart_characters_it4_v1.ckpt -o \"{model_storage_dir}/trinart_characters_it4_v1.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/naclbit/trinart_characters_19.2m_stable_diffusion_v1/resolve/main/trinart_characters_it4_v1.ckpt -d \"{model_storage_dir}\" -o \"trinart_characters_it4_v1.ckpt\""
    ]
   },
   {


### PR DESCRIPTION
…nged

after the last commit to use aria2c for model downloads

https://aria2.github.io/manual/en/html/aria2c.html?highlight=o#cmdoption-o

> -o, --out=<FILE>
The file name of the downloaded file. It is always relative to the directory given in [--dir](https://aria2.github.io/manual/en/html/aria2c.html?highlight=o#cmdoption-d) option.

so if i do something like run the launch webui cell - it will cd to the stable-diffusion-webui folder. I then stop the webui and go back up to download an extra model, aria2c will treat the -o value as filename so we will end up downloading model to e.g.

```Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
cfbadd|OK  |    14MiB/s|/notebooks/stable-diffusion-webui//storage/models/sd-v2-0-512-base-ema.ckpt
```

(its fine for the 1.0 sd models because you have the `%cd "{model_storage_dir}"` lines)