### PR TITLE
Add v2 yaml downloads

### DIFF
--- a/StableDiffusionUI_Voldemort_paperspace.ipynb
+++ b/StableDiffusionUI_Voldemort_paperspace.ipynb
@@ -479,7 +479,8 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-depth/resolve/main/512-depth-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-512-depth-ema.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-depth/resolve/main/512-depth-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-512-depth-ema.ckpt\"\n",
+    "!wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-midas-inference.yaml -O \"{model_storage_dir}/sd-v2-0-512-depth-ema.yaml\""
    ]
   },
   {

--- a/StableDiffusionUI_Voldemort_paperspace.ipynb
+++ b/StableDiffusionUI_Voldemort_paperspace.ipynb
@@ -507,7 +507,8 @@
     "    sys.exit(1)\n",
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
-    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-x4-upscaler/resolve/main/x4-upscaler-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-x4-upscaler-ema.ckpt\""
+    "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-x4-upscaler/resolve/main/x4-upscaler-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-x4-upscaler-ema.ckpt\"\n",
+    "!wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/x4-upscaling.yaml -O \"{model_storage_dir}/sd-v2-0-x4-upscaler-ema.yaml\""
    ]
   },
   {


### PR DESCRIPTION
Added yaml download codes since the v2 models are requires config files.

depth2img model is now supported in the Web UI.
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/5542

It seems that the x4 upscaler is not supported yet, but just in case.