### PR TITLE
fix URL for SD 2.0 512-base config file

### DIFF
--- a/StableDiffusionUI_Voldemort_paperspace.ipynb
+++ b/StableDiffusionUI_Voldemort_paperspace.ipynb
@@ -452,7 +452,7 @@
     "\n",
     "!if [ $(dpkg-query -W -f='${Status}' aria2 2>/dev/null | grep -c \"ok installed\") = 0 ]; then sudo apt update && sudo apt install -y aria2; fi\n",
     "!aria2c --file-allocation=none -c -x 16 -s 16 --summary-interval=0 https://huggingface.co/stabilityai/stable-diffusion-2-base/resolve/main/512-base-ema.ckpt -d \"{model_storage_dir}\" -o \"sd-v2-0-512-base-ema.ckpt\"\n",
-    "!wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-inference-v.yaml -O \"{model_storage_dir}/sd-v2-0-512-base-ema.yaml\""
+    "!wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-inference.yaml -O \"{model_storage_dir}/sd-v2-0-512-base-ema.yaml\""
    ]
   },
   {


### PR DESCRIPTION
fix to use the correct config file for SD 2.0 512 base model